### PR TITLE
Add rustls support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["geolocation", "ip", "locator", "geolocator", "geolocate"]
 categories = ["network-programming"]
 
 [dependencies]
-serde_json = "1.0.89"
+serde_json = "1.0.91"
 surf = { version = "2.3.2", default-features = false }
 futures = "0.3.25"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,19 @@ documentation = "https://docs.rs/ipgeolocate"
 keywords = ["geolocation", "ip", "locator", "geolocator", "geolocate"]
 categories = ["network-programming"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-serde_json = "1.0.64"
-surf = "2.2.0"
-futures = "0.3.13"
+serde_json = "1.0.89"
+surf = { version = "2.3.2", default-features = false }
+futures = "0.3.25"
 
 [dev-dependencies]
-tokio = { version = "1.4.0", features = ["full"] }
+tokio = { version = "1.23.0", features = ["full"] }
+
+[features]
+default = ["surf/default"]
+# Replace "curl-client" with "h1-client-rustls" in "surf/default"
+h1-client-rustls = [
+    "surf/h1-client-rustls",
+    "surf/middleware-logger",
+    "surf/encoding",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["network-programming"]
 [dependencies]
 serde_json = "1.0.91"
 surf = { version = "2.3.2", default-features = false }
-futures = "0.3.25"
+futures = "0.3.26"
 
 [dev-dependencies]
-tokio = { version = "1.24.1", features = ["full"] }
+tokio = { version = "1.25.0", features = ["full"] }
 
 [features]
 default = ["surf/default"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ surf = { version = "2.3.2", default-features = false }
 futures = "0.3.25"
 
 [dev-dependencies]
-tokio = { version = "1.23.0", features = ["full"] }
+tokio = { version = "1.24.1", features = ["full"] }
 
 [features]
 default = ["surf/default"]


### PR DESCRIPTION
# What did I do?

Add rustls support and update dependencies version.

# Why should I add rustls support?

After I did this, I can compile with [cross](https://github.com/cross-rs/cross) in macOS without `No package 'openssl' found` errors.

```sh
cross build --release --target x86_64-unknown-linux-musl
```

# Example

https://github.com/jerryshell/myip/blob/9625be129f48df5d42f37c954f77f9c4734c6c04/Cargo.toml#L15