### PR TITLE
feat: use reqwest instead of surf due to isahc panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,8 @@ categories = ["network-programming"]
 
 [dependencies]
 serde_json = "1.0.91"
-surf = { version = "2.3.2", default-features = false }
+reqwest = "0.11"
 futures = "0.3.26"
 
 [dev-dependencies]
 tokio = { version = "1.25.0", features = ["full"] }
-
-[features]
-default = ["surf/default"]
-# Replace "curl-client" with "h1-client-rustls" in "surf/default"
-h1-client-rustls = [
-    "surf/h1-client-rustls",
-    "surf/middleware-logger",
-    "surf/encoding",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ categories = ["network-programming"]
 serde_json = "1.0.91"
 reqwest = "0.11"
 futures = "0.3.26"
+tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1.25.0", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,10 +68,10 @@
 //! Written with love, in Rust.
 //!
 
+use reqwest::get;
 use serde_json::Value;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use surf::get;
 
 /// Services (apis) that can be used for accessing geolocation data.
 #[derive(Debug, Clone, Copy)]
@@ -175,7 +175,7 @@ impl Locator {
     async fn freegeoip(ip: &str) -> std::result::Result<Self, GeoError> {
         let url = format!("https://freegeoip.app/json/{}", ip);
 
-        let response = match get(&url).recv_string().await {
+        let response = match get(&url).await.unwrap().text().await {
             Ok(response) => response,
             Err(_) => {
                 return Err(GeoError::HttpError(
@@ -275,7 +275,7 @@ impl Locator {
     async fn ipwhois(ip: &str) -> std::result::Result<Self, GeoError> {
         let url = format!("http://ipwhois.app/json/{}", ip);
 
-        let response = match get(&url).recv_string().await {
+        let response = match get(&url).await.unwrap().text().await {
             Ok(response) => response,
             Err(_) => {
                 return Err(GeoError::HttpError(
@@ -390,7 +390,7 @@ impl Locator {
     async fn ipapi(ip: &str) -> std::result::Result<Self, GeoError> {
         let url = format!("http://ip-api.com/json/{}", ip);
 
-        let response = match get(&url).recv_string().await {
+        let response = match get(&url).await.unwrap().text().await {
             Ok(response) => response,
             Err(_) => {
                 return Err(GeoError::HttpError(
@@ -490,7 +490,7 @@ impl Locator {
     async fn ipapico(ip: &str) -> std::result::Result<Self, GeoError> {
         let url = format!("https://ipapi.co/{}/json/", ip);
 
-        let response = match get(&url).recv_string().await {
+        let response = match get(&url).await.unwrap().text().await {
             Ok(response) => response,
             Err(_) => {
                 return Err(GeoError::HttpError(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ use reqwest::get;
 use serde_json::Value;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use tracing::debug;
 
 /// Services (apis) that can be used for accessing geolocation data.
 #[derive(Debug, Clone, Copy)]
@@ -140,6 +141,8 @@ pub struct Locator {
     pub country: String,
     /// Timezone of the IP address.
     pub timezone: String,
+    /// ISP of the IP address
+    pub isp: String,
 }
 
 impl Locator {
@@ -258,6 +261,7 @@ impl Locator {
         let region = region.to_string();
         let country = country.to_string();
         let timezone = timezone.to_string();
+        let isp = String::default();
 
         let result = Locator {
             ip,
@@ -267,6 +271,7 @@ impl Locator {
             region,
             country,
             timezone,
+            isp,
         };
 
         Ok(result)
@@ -382,6 +387,7 @@ impl Locator {
             region,
             country,
             timezone,
+            isp: String::default(),
         };
 
         Ok(result)
@@ -409,6 +415,8 @@ impl Locator {
                 )));
             }
         };
+
+        debug!("ipgeolocate return object looks like: {}", parsed_json);
 
         // Get latitude from parsed_json
         let latitude = match &parsed_json["lat"] {
@@ -466,6 +474,15 @@ impl Locator {
             }
         };
 
+        let isp = match &parsed_json["isp"] {
+            Value::String(isp) => isp,
+            _ => {
+                return Err(GeoError::ParseError(
+                    "Unable to find timezone in parsed JSON".to_string(),
+                ));
+            }
+        };
+
         let ip = ip.to_string();
         let latitude = latitude.to_string();
         let longitude = longitude.to_string();
@@ -473,6 +490,7 @@ impl Locator {
         let region = region.to_string();
         let country = country.to_string();
         let timezone = timezone.to_string();
+        let isp = isp.to_string();
 
         let result = Locator {
             ip,
@@ -482,6 +500,7 @@ impl Locator {
             region,
             country,
             timezone,
+            isp,
         };
 
         Ok(result)
@@ -573,6 +592,7 @@ impl Locator {
         let region = region.to_string();
         let country = country.to_string();
         let timezone = timezone.to_string();
+        let isp: String = String::default();
 
         let result = Locator {
             ip,
@@ -582,6 +602,7 @@ impl Locator {
             region,
             country,
             timezone,
+            isp,
         };
 
         Ok(result)


### PR DESCRIPTION
hey there

see https://github.com/Keep-Reth-Strange/reth-crawler/pull/59 but it looks like this crate is susceptible to an underlying panic in a `surf-rs` dep

I've forked it to use `reqwest` instead, and opening this PR here to see if it makes sense to merge this upstream as well